### PR TITLE
Explicitly export types

### DIFF
--- a/.changeset/heavy-bikes-look.md
+++ b/.changeset/heavy-bikes-look.md
@@ -1,0 +1,5 @@
+---
+'bookmarked': patch
+---
+
+exported internal types

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,11 @@ export const bookmarked = (content?: (Bookmark | Folder)[]): string =>
     `  </P>`,
     `</DL>`,
   ].join('\n');
+
+export type {
+  Bookmark,
+  Folder,
+  FolderOrBookmarkProperties,
+  FolderProperties,
+  BookmarkProperties,
+} from './ts/types';


### PR DESCRIPTION
# What is this PR?

- Whilst types were built and compliant - they weren't easy for a consumer to get to