### PR TITLE
Added support for value-less attributes

### DIFF
--- a/.changeset/perfect-pumpkins-peel.md
+++ b/.changeset/perfect-pumpkins-peel.md
@@ -1,0 +1,5 @@
+---
+'bookmarked': patch
+---
+
+added support for value-less attributes

--- a/src/formatters/properties.ts
+++ b/src/formatters/properties.ts
@@ -1,8 +1,14 @@
 import { hasProperties } from '../utils';
 import type { FolderOrBookmarkProperties } from '../ts/types';
 
-const format = ([key, value]: [string, unknown]): `${string}="${string}"` =>
-  `${key}="${value}"`;
+const format = ([key, value]: [string, unknown]):
+  | `${string}="${string}"`
+  | `${string}` => {
+  if (value === true) {
+    return `${key}`;
+  }
+  return `${key}="${value}"`;
+};
 
 const formatProperties = (properties: FolderOrBookmarkProperties): string =>
   // adding a space to the start  " <H3 foo.../>"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,8 @@
 import { bookmarked } from './index';
 import BOOKMARKS from './test/fixtures/generate/bookmarks/index';
-import FOLDERS from './test/fixtures/generate/folders/index';
+import FOLDERS, {
+  SAFARI_READING_LIST,
+} from './test/fixtures/generate/folders/index';
 
 const {
   CODEBAR,
@@ -543,5 +545,33 @@ describe(`The generated file structure should conform to the 'NETSCAPE-Bookmark-
           </DL>"
         `);
     });
+  });
+});
+
+describe('edgecases', () => {
+  it("bookmarks exported from safari have a 'FOLDED' attribute (without a value)", () => {
+    expect(bookmarked([SAFARI_READING_LIST])).toMatchInlineSnapshot(`
+      "<!DOCTYPE NETSCAPE-Bookmark-file-1>
+      <!-- This is an automatically generated file.
+           It will be read and overwritten.
+           DO NOT EDIT! -->
+      <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+      <TITLE>Bookmarks</TITLE>
+      <H1>Bookmarks</H1>
+      <DL>
+        <P>
+          <DT>
+            <H3 id="com.apple.ReadingList" FOLDED>Reading List</H3>
+          </DT>
+          <DL>
+            <P>
+              <DT>
+                <A HREF="https://poignant.guide/book/chapter-1.html">Why's (Poignant) Guide to Ruby</A>
+              </DT>
+            </P>
+          </DL>
+        </P>
+      </DL>"
+    `);
   });
 });

--- a/src/test/fixtures/generate/folders/folder__safari.ts
+++ b/src/test/fixtures/generate/folders/folder__safari.ts
@@ -1,0 +1,15 @@
+import type { Folder } from '../../../../ts/types';
+
+export const SAFARI_READING_LIST: Folder = {
+  name: 'Reading List',
+  properties: {
+    id: 'com.apple.ReadingList',
+    FOLDED: true,
+  },
+  children: [
+    {
+      name: `Why's (Poignant) Guide to Ruby`,
+      href: 'https://poignant.guide/book/chapter-1.html',
+    },
+  ],
+};

--- a/src/test/fixtures/generate/folders/index.ts
+++ b/src/test/fixtures/generate/folders/index.ts
@@ -29,4 +29,6 @@ const FOLDERS = {
   FOLDER_WITH_CUSTOM_PROPERTIES,
 };
 
+export { SAFARI_READING_LIST } from './folder__safari';
+
 export default FOLDERS;

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -1,5 +1,5 @@
 interface Record {
-  [key: string]: string | undefined;
+  [key: string]: string | true | undefined;
 }
 
 export interface Bookmark {


### PR DESCRIPTION
# What is this PR?

Safari adds the `FOLDED` property to bookmark files 🤷‍♂️ 

# Checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Does this PR introduce a breaking change? (please elaborate below)
